### PR TITLE
build: merge build and deploy jobs into one

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,10 @@ permissions:
   # So that URL preview link can be commented on the PR
   pull-requests: write
 
+# Deploy to Netlify guide:
+# https://www.raulmelo.me/en/blog/deploying-netlify-github-actions-guide
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,37 +44,10 @@ jobs:
         run: |
           pnpm build
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build
-          # this should match the `pages` option in your adapter-static options
-          path: 'build/'
-
-  # Deploy to Netlify guide:
-  # https://www.raulmelo.me/en/blog/deploying-netlify-github-actions-guide
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 8
-
       - name: Install Netlify
         run: pnpm install -g netlify-cli@17.23.5
 
-      # Download the build artifact from the previous `build` job
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: build
-          path: build
-
       - name: Deploy to Netlify
-        id: netlify_deploy
         run: |
           prod_flag=""
           if [ "$BRANCH_NAME" = "main" ]; then prod_flag="--prod"; fi


### PR DESCRIPTION
## Description

In `deploy.yml`, merges the `build` and `deploy` steps together since separating them is not necessary.

[Before](https://github.com/AnsonH/plinko-game/actions/runs/9137347629):

![image](https://github.com/AnsonH/plinko-game/assets/57580593/c55d134b-80a5-41a2-b157-33017a6e417b)

After:

![image](https://github.com/AnsonH/plinko-game/assets/57580593/8e632a38-da5f-47b8-8747-d407aa853bff)
