### PR TITLE
perf: write balance to local storage on beforeunload

### DIFF
--- a/src/lib/stores/game.ts
+++ b/src/lib/stores/game.ts
@@ -1,5 +1,5 @@
 import PlinkoEngine from '$lib/components/Plinko/PlinkoEngine';
-import { LOCAL_STORAGE_KEY, binColor } from '$lib/constants/game';
+import { binColor } from '$lib/constants/game';
 import {
   RiskLevel,
   type BetAmountOfExistingBalls,
@@ -8,7 +8,6 @@ import {
 } from '$lib/types';
 import { interpolateRgbColors } from '$lib/utils/colors';
 import { countValueOccurrences } from '$lib/utils/numbers';
-import { persisted } from 'svelte-persisted-store';
 import { derived, writable } from 'svelte/store';
 
 export const plinkoEngine = writable<PlinkoEngine | null>(null);
@@ -31,7 +30,14 @@ export const winRecords = writable<WinRecord[]>([]);
  */
 export const totalProfitHistory = writable<number[]>([0]);
 
-export const balance = persisted<number>(LOCAL_STORAGE_KEY.BALANCE, 200);
+/**
+ * Game balance, which is saved to local storage.
+ *
+ * We only save the balance to local storage on browser `beforeunload` event instead of
+ * on every balance change. This prevents unnecessary writes to local storage, which can
+ * be slow on low-end devices.
+ */
+export const balance = writable<number>(200);
 
 /**
  * RGB colors for every bin. The length of the array is the number of bins.

--- a/src/lib/utils/game.ts
+++ b/src/lib/utils/game.ts
@@ -1,0 +1,15 @@
+import { LOCAL_STORAGE_KEY } from '$lib/constants/game';
+import { balance } from '$lib/stores/game';
+import { get } from 'svelte/store';
+
+export function setBalanceFromLocalStorage() {
+  const balanceVal = window.localStorage.getItem(LOCAL_STORAGE_KEY.BALANCE);
+  if (balanceVal) {
+    balance.set(parseFloat(balanceVal));
+  }
+}
+
+export function writeBalanceToLocalStorage() {
+  const balanceVal = get(balance).toFixed(2);
+  window.localStorage.setItem(LOCAL_STORAGE_KEY.BALANCE, balanceVal);
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,8 +5,16 @@
   import Plinko from '$lib/components/Plinko';
   import SettingsWindow from '$lib/components/SettingsWindow';
   import Sidebar from '$lib/components/Sidebar';
+  import { setBalanceFromLocalStorage, writeBalanceToLocalStorage } from '$lib/utils/game';
   import GitHubLogo from 'phosphor-svelte/lib/GithubLogo';
+  import { onMount } from 'svelte';
+
+  onMount(() => {
+    setBalanceFromLocalStorage();
+  });
 </script>
+
+<svelte:window on:beforeunload={writeBalanceToLocalStorage} />
 
 <div class="relative flex min-h-dvh w-full flex-col">
   <nav class="sticky top-0 z-10 w-full bg-gray-700 px-5 drop-shadow-lg">


### PR DESCRIPTION
## Description

Ditches the use of [svelte-persisted-store](https://github.com/joshnuss/svelte-persisted-store) for the `balance` state, so that we writes the wallet balance value to local storage only on Window's [`beforeunload` event](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event) instead of writing on every value change.

### Motivation

While I'm trying to debug performance issues, I noticed that every `dropBall` call has an `updateStorage` call to update the local storage. While this occupies a small amount of time, my computer has a fast SSD so writing to disk is fast. The same cannot be said for low-end devices where I/O time is slow. 

![image](https://github.com/AnsonH/plinko-game/assets/57580593/d2b6327e-3536-450a-83a8-161560d23a54)
