### PR TITLE
ci: trigger production deployment only on release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ permissions:
 # https://www.raulmelo.me/en/blog/deploying-netlify-github-actions-guide
 jobs:
   build-and-deploy:
+    if: github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'chore(release)')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ To visit this page, visit the below URL after starting the development server wi
 http://localhost:5173/benchmark
 ```
 
+## Release
+
+This project uses [Netlify](https://www.netlify.com/) for deployment. To trigger a production deployment, create a commit with message starting with `chore(release)` in the `main` branch.
+
 ## More Screenshots
 
 Mobile:


### PR DESCRIPTION
## Description

Triggers deployment to production only on `chore(release)` commit message. Preview site deployments for PRs is not affected.