### PR TITLE
ci: use ubuntu-22.04 to fix Playwright issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,9 @@ permissions:
 jobs:
   build-and-deploy:
     if: github.event_name == 'pull_request' || contains(github.event.head_commit.message, 'chore(release)')
-    runs-on: ubuntu-latest
+    # Locked to Ubuntu 22 since Playwright has issues with 24
+    # https://github.com/microsoft/playwright/issues/30368
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    # Locked to Ubuntu 22 since Playwright has issues with 24
+    # https://github.com/microsoft/playwright/issues/30368
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
There was an issue when installing Playwright in Ubuntu 24: https://github.com/microsoft/playwright/issues/30368#issuecomment-2636086921

https://github.com/AnsonH/plinko-game/actions/runs/13344921888/job/37274218098?pr=29

![image](https://github.com/user-attachments/assets/c7e3ca13-40b8-4155-89fb-58d45adbd361)
