### PR TITLE
build(deps): bump bits-ui to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@neodrag/svelte": "^2.0.6",
-    "bits-ui": "^1.1.0",
+    "bits-ui": "^1.2.0",
     "chart.js": "^4.4.2",
     "matter-js": "^0.19.0",
     "svelte-persisted-store": "^0.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.0.6
         version: 2.0.6
       bits-ui:
-        specifier: ^1.1.0
-        version: 1.1.0(svelte@5.16.1)
+        specifier: ^1.2.0
+        version: 1.2.0(svelte@5.16.1)
       chart.js:
         specifier: ^4.4.2
         version: 4.4.2
@@ -724,8 +724,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  bits-ui@1.1.0:
-    resolution: {integrity: sha512-fnMO3LrNIjWfirm0UJ/kewH5PTi4BobhGpLoZzN2bc/YnsNQ0NcIWkLDJdrrNSTpcfYuwlJpIVGK96tc1FXa5Q==}
+  bits-ui@1.2.0:
+    resolution: {integrity: sha512-q+zZGtrDRyDYd58nSJj3gGDJ7AmxEJXZVuO/bQAe7GHrFXBwRCGdiA3GI+vTlQpnQTYubBXGIWnyBDYvQoe/YQ==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.11.0
@@ -2316,7 +2316,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  bits-ui@1.1.0(svelte@5.16.1):
+  bits-ui@1.2.0(svelte@5.16.1):
     dependencies:
       '@floating-ui/core': 1.6.9
       '@floating-ui/dom': 1.6.13

--- a/src/lib/components/LiveStatsWindow/LiveStatsWindow.svelte
+++ b/src/lib/components/LiveStatsWindow/LiveStatsWindow.svelte
@@ -36,7 +36,6 @@
           </Tooltip.Trigger>
           <Tooltip.Content
             forceMount
-            interactOutsideBehavior="ignore"
             sideOffset={4}
             class="z-50 max-w-lg rounded-md bg-white p-3 text-sm font-medium text-gray-950 drop-shadow-xl"
           >

--- a/src/lib/components/Sidebar/Sidebar.svelte
+++ b/src/lib/components/Sidebar/Sidebar.svelte
@@ -278,7 +278,6 @@
           </Tooltip.Trigger>
           <Tooltip.Content
             forceMount
-            interactOutsideBehavior="ignore"
             sideOffset={4}
             class="z-30 max-w-lg rounded-md bg-white p-3 text-sm font-medium text-gray-950 drop-shadow-xl"
           >
@@ -308,7 +307,6 @@
           </Tooltip.Trigger>
           <Tooltip.Content
             forceMount
-            interactOutsideBehavior="ignore"
             sideOffset={4}
             class="z-30 max-w-lg rounded-md bg-white p-3 text-sm font-medium text-gray-950 drop-shadow-xl"
           >


### PR DESCRIPTION
Bumps [Bits UI to 1.2.0](https://github.com/huntabyte/bits-ui/releases/tag/bits-ui%401.2.0), which fixes a bug where we no longer need to add `interactOutsideBehavior="ignore"` to `Tooltip.Content` when `Tooltip.Provider` has `disableCloseOnTriggerClick` 